### PR TITLE
fix(bufferlist): display correct basename on Windows

### DIFF
--- a/lua/vessel/bufferlist/init.lua
+++ b/lua/vessel/bufferlist/init.lua
@@ -748,7 +748,7 @@ function Bufferlist:_get_buffers()
 		end
 
 		local buffer = Buffer:new(b.bufnr)
-		buffer.path = b.name
+		buffer.path = vim.fs.joinpath(vim.fs.dirname(b.name), vim.fs.basename(b.name))
 		buffer.listed = b.listed == 1
 		buffer.modified = b.changed == 1
 		buffer.changedtick = b.changedtick

--- a/lua/vessel/bufferlist/tree.lua
+++ b/lua/vessel/bufferlist/tree.lua
@@ -137,7 +137,8 @@ function M.make_trees(buffers, groups)
 		_groups[g] = Tree:new(g)
 	end
 
-	local cwd = vim.fn.getcwd()
+	local _cwd = vim.fn.getcwd()
+	local cwd = vim.fs.joinpath(vim.fs.dirname(_cwd), vim.fs.basename(_cwd))
 	local home = os.getenv("HOME") or "/home"
 
 	-- therse groups are always going to be present
@@ -167,7 +168,10 @@ function M.make_trees(buffers, groups)
 			goto continue
 		end
 		for _, prefix in ipairs(prefixes) do
-			if vim.startswith(buffer.path, util.trim_path(prefix) .. "/") then
+			local _dirname = vim.fs.dirname(buffer.path)
+			local _basename = vim.fs.basename(buffer.path)
+			local buffer_path = vim.fs.joinpath(_dirname, _basename)
+			if vim.startswith(buffer_path, util.trim_path(prefix) .. "/") then
 				_groups[prefix]:insert(buffer, util.replstart(buffer.path, prefix, ""))
 				goto continue
 			end


### PR DESCRIPTION
On Windows, we're seeing this:

<img width="1240" alt="Screenshot 2024-11-09 at 14 09 08" src="https://github.com/user-attachments/assets/057170d6-87c6-4554-b4fb-c0e730e49011">

To fix it, we standardize the way as the full path filename is stored on the buffers table, by using `vim.fs` builtin functions. Instead of storing it with `\\` separators, it uses `/` even on Windows.